### PR TITLE
Rollback sarama version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ONSdigital/dp-vault v1.1.2
 	github.com/ONSdigital/go-ns v0.0.0-20200902154605-290c8b5ba5eb
 	github.com/ONSdigital/log.go v1.0.1
-	github.com/Shopify/sarama v1.27.2 // indirect
+	github.com/Shopify/sarama v1.24.1 // indirect
 	github.com/aws/aws-sdk-go v1.36.27
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/golang/snappy v0.0.2 // indirect


### PR DESCRIPTION
### What

Rollback the version of sarama as an upgrade to `dp-kafka/v2` is
required which is a more significant rework that needs to be done when
we have more time.

### Who can review

Anyone but me.
