### PR TITLE
Update go version to bullseye in  yaml files

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.21.4
+    tag: 1.21.6-bullseye
 
 inputs:
   - name: dp-image-importer

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.21.4
+    tag: 1.21.6-bullseye
 
 inputs:
   - name: dp-image-importer


### PR DESCRIPTION
### What

Updated go version to bullseye in the yaml files to fix the sandbox ship it pipeline error:

`/lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.32 not found`

### How to review

Visual Check

### Who can review

Anyone
