### PR TITLE
Upgrade go to 1.26.2

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-image-importer

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-image-importer


### PR DESCRIPTION
### What

The version of go has been increased from 1.26.1 to 1.26.2, to fix audit failures.

### How to review

Sense check. Tests pass.

### Who can review

Anyone.